### PR TITLE
Fix English typo: Prokect/Project

### DIFF
--- a/index.markdown
+++ b/index.markdown
@@ -41,140 +41,140 @@ Do not combine separate membership requests in a single thread; one request per 
 			<a href="#" class="project-title" title="Agavi">Agavi</a>
 			<div class="project-info"> 
 				<p>Project Website: <a target="_blank" href="http://www.agavi.org/">www.agavi.org</a></p>
-				<p>Prokect Lead: David Zülke (<a href="http://twitter.com/#!/dzuelke/">@dzuelke</a>)</p>
+				<p>Project Lead: David Zülke (<a href="http://twitter.com/#!/dzuelke/">@dzuelke</a>)</p>
 			</div>
 		</li>
 		<li>
 			<a href="#" class="project-title" title="Amazon Web Services SDK">Amazon Web Services SDK</a>
 			<div class="project-info"> 
 				<p>Project Website: <a target="_blank" href="http://aws.amazon.com/sdkforphp/">aws.amazon.com/sdkforphp</a></p>
-				<p>Prokect Lead: Ryan Parman (<a href="http://twitter.com/#!/Skyzyx/">@Skyzyx</a>)</p>
+				<p>Project Lead: Ryan Parman (<a href="http://twitter.com/#!/Skyzyx/">@Skyzyx</a>)</p>
 			</div>
 		</li>
 		<li>
 			<a href="#" class="project-title" title="Assetic and Buzz">Assetic | Buzz</a>
 			<div class="project-info"> 
 				<p>Project Website: <a target="_blank" href="http://github.com/kriswallsmith/assetic/">github.com/kriswallsmith/assetic</a> <a target="_blank" href="https://github.com/kriswallsmith/Buzz">github.com/kriswallsmith/Buzz</a></p>
-				<p>Prokect Lead: Kris Wallsmith (<a href="http://twitter.com/#!/kriswallsmith/">@kriswallsmith</a>)</p>
+				<p>Project Lead: Kris Wallsmith (<a href="http://twitter.com/#!/kriswallsmith/">@kriswallsmith</a>)</p>
 			</div>
 		</li>
 		<li>
 			<a href="#" class="project-title" title="CakePHP">CakePHP</a>
 			<div class="project-info"> 
 				<p>Project Website: <a target="_blank" href="http://cakephp.org/">cakephp.org</a></p>
-				<p>Prokect Lead: Larry Masters (<a href="http://twitter.com/#!/PhpNut/">@PhpNut</a>)</p>
+				<p>Project Lead: Larry Masters (<a href="http://twitter.com/#!/PhpNut/">@PhpNut</a>)</p>
 			</div>
 		</li>
 		<li>
 			<a href="#" class="project-title" title="Chisimba">Chisimba</a>
 			<div class="project-info"> 
 				<p>Project Website: <a target="_blank" href="http://www.chisimba.com">www.chisimba.com</a></p>
-				<p>Prokect Lead: Paul Scott (<a href="http://twitter.com/#!/paulscott56/">@paulscott56</a>)</p>
+				<p>Project Lead: Paul Scott (<a href="http://twitter.com/#!/paulscott56/">@paulscott56</a>)</p>
 			</div>
 		</li>
 		<li>
 			<a href="#" class="project-title" title="Composer and Packagist">Composer | Packagist</a>
 			<div class="project-info"> 
 				<p>Project Website: <a target="_blank" href="http://getcomposer.org/">getcomposer.org</a> <a target="_blank" href="http://packagist.org/">packagist.org</a></p>
-				<p>Prokect Lead: Jordi Boggiano (<a href="http://twitter.com/#!/seldaek/">@seldaek</a>)</p>
+				<p>Project Lead: Jordi Boggiano (<a href="http://twitter.com/#!/seldaek/">@seldaek</a>)</p>
 			</div>
 		</li>
 		<li>
 			<a href="#" class="project-title" title="Doctrine">Doctrine</a>
 			<div class="project-info"> 
 				<p>Project Website: <a target="_blank" href="http://www.doctrine-project.org">www.doctrine-project.org</a></p>
-				<p>Prokect Lead: Guilherme Blanco (<a href="http://twitter.com/#!/guilhermeblanco/">@guilhermeblanco</a>)</p>
+				<p>Project Lead: Guilherme Blanco (<a href="http://twitter.com/#!/guilhermeblanco/">@guilhermeblanco</a>)</p>
 			</div>
 		</li>
 		<li>
 			<a href="#" class="project-title" title="Drupal">Drupal</a>
 			<div class="project-info"> 
 				<p>Project Website: <a target="_blank" href="http://drupal.org">drupal.org</a></p>
-				<p>Prokect Lead: Larry Garfield (<a href="http://twitter.com/#!/Crell/">@Crell</a>)</p>
+				<p>Project Lead: Larry Garfield (<a href="http://twitter.com/#!/Crell/">@Crell</a>)</p>
 			</div>
 		</li>
 		<li>
 			<a href="#" class="project-title" title="eZ Publish">eZ Publish</a>
 			<div class="project-info"> 
 				<p>Project Website: <a target="_blank" href="http://ez.no/">ez.no</a></p>
-				<p>Prokect Lead: Andre Romcke (<a href="http://twitter.com/#!/andrerom/">@andrerom</a>)</p>
+				<p>Project Lead: Andre Romcke (<a href="http://twitter.com/#!/andrerom/">@andrerom</a>)</p>
 			</div>
 		</li>
 		<li>
 			<a href="#" class="project-title" title="FLOW3">FLOW3</a>
 			<div class="project-info"> 
 				<p>Project Website: <a target="_blank" href="http://flow3.typo3.org/">flow3.typo3.org</a></p>
-				<p>Prokect Lead: Robert Lemke (<a href="http://twitter.com/#!/robertlemke/">@robertlemke</a>)</p>
+				<p>Project Lead: Robert Lemke (<a href="http://twitter.com/#!/robertlemke/">@robertlemke</a>)</p>
 			</div>
 		</li>
 		<li>
 			<a href="#" class="project-title" title="Joomla">Joomla</a>
 			<div class="project-info"> 
 				<p>Project Website: <a target="_blank" href="http://www.joomla.org/">www.joomla.org</a></p>
-				<p>Prokect Lead: Andrew Eddie (<a href="http://twitter.com/#!/AndrewEddie/">@AndrewEddie</a>)</p>
+				<p>Project Lead: Andrew Eddie (<a href="http://twitter.com/#!/AndrewEddie/">@AndrewEddie</a>)</p>
 			</div>
 		</li>
 		<li>
 			<a href="#" class="project-title" title="Lithium">Lithium</a>
 			<div class="project-info"> 
 				<p>Project Website: <a target="_blank" href="http://lithify.me/">lithify.me</a></p>
-				<p>Prokect Lead: Nate Abele (<a href="http://twitter.com/#!/nateabele/">@nateabele</a>)</p>
+				<p>Project Lead: Nate Abele (<a href="http://twitter.com/#!/nateabele/">@nateabele</a>)</p>
 			</div>
 		</li>
 		<li>
 			<a href="#" class="project-title" title="PEAR">PEAR</a>
 			<div class="project-info"> 
 				<p>Project Website: <a target="_blank" href="http://pear.php.net/">pear.php.net</a></p>
-				<p>Prokect Lead: Brett Bieber (<a href="http://twitter.com/#!/saltybeagle/">@saltybeagle</a>)</p>
+				<p>Project Lead: Brett Bieber (<a href="http://twitter.com/#!/saltybeagle/">@saltybeagle</a>)</p>
 			</div>
 		</li>
 		<li>
 			<a href="#" class="project-title" title="phpBB">phpBB</a>
 			<div class="project-info"> 
 				<p>Project Website: <a target="_blank" href="http://www.phpbb.com/">www.phpbb.com</a></p>
-				<p>Prokect Lead: Nils Adermann (<a href="http://twitter.com/#!/naderman/">@naderman</a>)</p>
+				<p>Project Lead: Nils Adermann (<a href="http://twitter.com/#!/naderman/">@naderman</a>)</p>
 			</div>
 		</li>
 		<li>
 			<a href="#" class="project-title" title="PPI">PPI</a>
 			<div class="project-info"> 
 				<p>Project Website: <a target="_blank" href="http://www.ppi.io/">www.ppi.io</a></p>
-				<p>Prokect Lead: Paul Dragoonis (<a href="http://twitter.com/#!/dr4goonis/">@dr4goonis</a>)</p>
+				<p>Project Lead: Paul Dragoonis (<a href="http://twitter.com/#!/dr4goonis/">@dr4goonis</a>)</p>
 			</div>
 		</li>
 		<li>
 			<a href="#" class="project-title" title="Propel">Propel</a>
 			<div class="project-info"> 
 				<p>Project Website: <a target="_blank" href="http://www.propelorm.org/">www.propelorm.org</a></p>
-				<p>Prokect Lead: William Durand (<a href="http://twitter.com/#!/couac/">@couac</a>)</p>
+				<p>Project Lead: William Durand (<a href="http://twitter.com/#!/couac/">@couac</a>)</p>
 			</div>
 		</li>
 		<li>
 			<a href="#" class="project-title" title="PyroCMS">PyroCMS</a>
 			<div class="project-info"> 
 				<p>Project Website: <a target="_blank" href="http://www.pyrocms.com/">www.pyrocms.com</a></p>
-				<p>Prokect Lead: Phil Sturgeon (<a href="http://twitter.com/#!/philsturgeon/">@philsturgeon</a>)</p>
+				<p>Project Lead: Phil Sturgeon (<a href="http://twitter.com/#!/philsturgeon/">@philsturgeon</a>)</p>
 			</div>
 		</li>
 		<li>
 			<a href="#" class="project-title" title="SabreDAV">SabreDAV</a>
 			<div class="project-info"> 
 				<p>Project Website: <a target="_blank" href="http://www.sabredav.org/">www.sabredav.org</a></p>
-				<p>Prokect Lead: Evert Pot (<a href="http://twitter.com/#!/evertp/">@evertp</a>)</p>
+				<p>Project Lead: Evert Pot (<a href="http://twitter.com/#!/evertp/">@evertp</a>)</p>
 			</div>
 		</li>
 		<li>
 			<a href="#" class="project-title" title="Solar Framework and Aura Project">Solar Framework | Aura Project</a>
 			<div class="project-info"> 
 				<p>Project Website: <a target="_blank" href="http://www.solarphp.com/">www.solarphp.com</a> <a target="_blank" href="http://auraphp.github.com/">auraphp.github.com</a></p>
-				<p>Prokect Lead: Paul M. Jones (<a href="http://twitter.com/#!/pmjones/">@pmjones</a>)</p>
+				<p>Project Lead: Paul M. Jones (<a href="http://twitter.com/#!/pmjones/">@pmjones</a>)</p>
 			</div>
 		</li>
 		<li>
 			<a href="#" class="project-title" title="Symfony2">Symfony2</a>
 			<div class="project-info"> 
 				<p>Project Website: <a target="_blank" href="http://www.symfony.com/">www.symfony.com</a></p>
-				<p>Prokect Lead: Fabien Potencier (<a href="http://twitter.com/#!/fabpot/">@fabpot</a>)</p>
+				<p>Project Lead: Fabien Potencier (<a href="http://twitter.com/#!/fabpot/">@fabpot</a>)</p>
 			</div>
 		</li>
 		<li>
@@ -187,14 +187,14 @@ Do not combine separate membership requests in a single thread; one request per 
 			<a href="#" class="project-title" title="Zend Framework 2">Zend Framework 2</a>
 			<div class="project-info"> 
 				<p>Project Website: <a target="_blank" href="http://framework.zend.com/">framework.zend.com</a></p>
-				<p>Prokect Lead: Matthew Weier O'Phinney (<a href="http://twitter.com/#!/weierophinney/">@weierophinney</a>)</p>
+				<p>Project Lead: Matthew Weier O'Phinney (<a href="http://twitter.com/#!/weierophinney/">@weierophinney</a>)</p>
 			</div>
 		</li>
 		<li>
 			<a href="#" class="project-title" title="Zikula">Zikula</a>
 			<div class="project-info"> 
 				<p>Project Website: <a target="_blank" href="http://www.zikula.org/">www.zikula.org</a></p>
-				<p>Prokect Lead: Karma Dordrak (<a href="http://twitter.com/#!/zikuladrak/">@zikuladrak</a>)</p>
+				<p>Project Lead: Karma Dordrak (<a href="http://twitter.com/#!/zikuladrak/">@zikuladrak</a>)</p>
 			</div>
 		</li>
 	</ul>


### PR DESCRIPTION
There's a repeated typo on the list of member projects: "Prokect Lead".
I've fixed these to say "Project Lead".
