### PR TITLE
adding the php-fig-cs mailinglist

### DIFF
--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -5,6 +5,11 @@
 		Mailing List
 	</a>
 
+	<a href="https://groups.google.com/forum/?fromgroups#!forum/php-fig-cs" class="button"  id="mailing-list-button" target="_blank">
+		<small>Join Our</small>
+		CS Mailing List
+	</a>
+
 	<a href="/faq/" class="button"  id="faq-button">
 		<small>Frequently Asked</small>
 		Questions


### PR DESCRIPTION
I ended up using "CS Mailing List" because "Coding Style Mailing List" seemed too long. For those unsure what CS standards for, they can read the description of the google group itself
