### PR TITLE
Remove target="_blank" from IRC sidebar link

### DIFF
--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -10,7 +10,7 @@
 		CS Mailing List
 	</a>
 
-	<a href="/irc/" class="button" target="_blank">
+	<a href="/irc/" class="button">
 		<small>freenode#phpfig</small>
 		IRC Chat
 	</a>


### PR DESCRIPTION
IRC page should not open in a new window/tab
