### PR TITLE
Add target="_blank" to fullscreen IRC link

### DIFF
--- a/irc/index.markdown
+++ b/irc/index.markdown
@@ -15,9 +15,8 @@ and is called [#phpfig][irc-channel].
 
 ## Web Interface
 
-A [full-page web interface][irc-fullscreen] is also available.
+A <a href="/irc/fullscreen/" target="_blank">full-page web interface</a> is also available (opens in a new tab).
 
   [mailing]: http://groups.google.com/group/php-fig/
   [freenode]: http://www.freenode.net
   [irc-channel]: irc://freenode.net/phpfig
-  [irc-fullscreen]: /irc/fullscreen/


### PR DESCRIPTION
Fullscreen IRC interface should open in new tab - see discussion on issue #51

> Meaning the 'full screen' link will open in a new tab and they can't navigate around the website.
