### PR TITLE
Gender nuetral language

### DIFF
--- a/faq/index.markdown
+++ b/faq/index.markdown
@@ -18,8 +18,8 @@ The idea behind the group is for project representatives to talk about the
 commonalities between our projects and find ways we can work together. Our main
 audience is each other, but we’re very aware that the rest of the PHP community
 is watching. If other folks want to adopt what we’re doing they are welcome to
-do so, but that is not the aim. Nobody in the group wants to tell you — Joe
-Programmer — how to build your application.
+do so, but that is not the aim. Nobody in the group wants to tell you, as a programmer, 
+how to build your application.
 
 
 ## What standards have been passed so far?


### PR DESCRIPTION
Joe Programmer could offend. Better to avoid the discussion since no one intends to include Joe but exclude Jo. Always safe to shoot for gender neutral language.
