### PR TITLE
Replace :rubygems in Gemfile with 'https://rubygems.org'.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source :rubygems
+source 'https://rubygems.org'
 
 gem "jekyll"
 gem "rdiscount"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,5 @@
 GEM
-  remote: http://rubygems.org/
+  remote: https://rubygems.org/
   specs:
     albino (1.3.3)
       posix-spawn (>= 0.3.6)


### PR DESCRIPTION
Bundler some time ago started display warning message like follow:

``` sh
$ bundle install

The source :rubygems is deprecated because HTTP requests are insecure.
Please change your source to 'https://rubygems.org' if possible, or 'http://rubygems.org' if not.
...
```

So, this thange is to remove it and let everything go smother :)

(I'm using bundler version 1.3.5)

Please read more:
- [bundler commit(bc4403b): warn on deprecated symbol source](https://github.com/bundler/bundler/commit/d30026e9c8fc6c98478120866a47ca5b619251b8)
