### PR TITLE
Updated AWS voting rep to @mtdowling

### DIFF
--- a/index.markdown
+++ b/index.markdown
@@ -44,8 +44,11 @@ Do not combine separate membership requests in a single thread; one request per 
     </li>
     
     <li>
-        <h4><a target="_blank" href="http://aws.amazon.com/sdkforphp/">Amazon Web Services SDK</a></h4>
-        Ryan Parman (<a href="http://twitter.com/Skyzyx/">@Skyzyx</a>)
+        <h4>
+            <a target="_blank" href="http://aws.amazon.com/sdkforphp/">AWS SDK for PHP</a>
+            and <a target="_blank" href="http://guzzlephp.org/">Guzzle</a>
+        </h4>
+        Michael Dowling (<a href="http://twitter.com/mtdowling/">@mtdowling</a>)
     </li>
     
     <li>


### PR DESCRIPTION
I am updating the voting rep for the AWS SDK for PHP member project. See https://groups.google.com/forum/#!topic/php-fig/y3Kz8HiUcmg

I also corrected the name of the AWS SDK for PHP and added Guzzle since Michael is project lead of that project as well, and it would not make sense for us to request membership for this project seperately. Is this appropriate?

Why am I making this PR? Because I work with Michael on the AWS SDK for PHP and a little on Guzzle too. I figured he just forgot to do this PR, and my OCD was bothering me. Fine with you @mtdowling?
