### PR TITLE
Visual separator for the language menu

### DIFF
--- a/psr/psr-0/es/index.markdown
+++ b/psr/psr-0/es/index.markdown
@@ -5,9 +5,9 @@ title:  PSR-0 - Autoloading Standard
 
 <nav id="lngmenu">
   Available translations:
-  <a href="/psr/psr-0">English (official)</a>
-  <b>Spanish</b>
-  <a href="/psr/psr-0/fr">French</a>
+  <a href="/psr/psr-0">English (official)</a>,
+  <b>Spanish</b>,
+  <a href="/psr/psr-0/fr">French</a>,
   <a href="/psr/psr-0/it">Italian</a>
 </nav>
 

--- a/psr/psr-0/fr/index.markdown
+++ b/psr/psr-0/fr/index.markdown
@@ -5,9 +5,9 @@ title:  PSR-0 - Autoloading Standard
 
 <nav id="lngmenu">
   Available translations:
-  <a href="/psr/psr-0">English (official)</a>
-  <a href="/psr/psr-0/es">Spanish</a>
-  <b>French</b>
+  <a href="/psr/psr-0">English (official)</a>,
+  <a href="/psr/psr-0/es">Spanish</a>,
+  <b>French</b>,
   <a href="/psr/psr-0/it">Italian</a>
 </nav>
 

--- a/psr/psr-0/index.markdown
+++ b/psr/psr-0/index.markdown
@@ -5,9 +5,9 @@ title:  PSR-0 - Autoloading Standard
 
 <nav id="lngmenu">
   Available translations:
-  <b>English (official)</b>
-  <a href="/psr/psr-0/es">Spanish</a>
-  <a href="/psr/psr-0/fr">French</a>
+  <b>English (official)</b>,
+  <a href="/psr/psr-0/es">Spanish</a>,
+  <a href="/psr/psr-0/fr">French</a>,
   <a href="/psr/psr-0/it">Italian</a>
 </nav>
 

--- a/psr/psr-0/it/index.markdown
+++ b/psr/psr-0/it/index.markdown
@@ -5,9 +5,9 @@ title:  PSR-0 - Autoloading Standard
 
 <nav id="lngmenu">
   Available translations:
-  <a href="/psr/psr-0">English (official)</a>
-  <a href="/psr/psr-0/es">Spanish</a>
-  <a href="/psr/psr-0/fr">French</a>
+  <a href="/psr/psr-0">English (official)</a>,
+  <a href="/psr/psr-0/es">Spanish</a>,
+  <a href="/psr/psr-0/fr">French</a>,
   <b>Italian</b>
 </nav>
 

--- a/psr/psr-1/es/index.markdown
+++ b/psr/psr-1/es/index.markdown
@@ -5,9 +5,9 @@ title:  PSR-1 - Basic Coding Standard
 
 <nav id="lngmenu">
   Available translations:
-  <a href="/psr/psr-1">English (official)</a>
-  <b>Spanish</b>
-  <a href="/psr/psr-1/fr">French</a>
+  <a href="/psr/psr-1">English (official)</a>,
+  <b>Spanish</b>,
+  <a href="/psr/psr-1/fr">French</a>,
   <a href="/psr/psr-1/it">Italian</a>
 </nav>
 

--- a/psr/psr-1/fr/index.markdown
+++ b/psr/psr-1/fr/index.markdown
@@ -5,9 +5,9 @@ title:  PSR-1 - Basic Coding Standard
 
 <nav id="lngmenu">
   Available translations:
-  <a href="/psr/psr-1">English (official)</a>
-  <a href="/psr/psr-1/es">Spanish</a>
-  <b>French</b>
+  <a href="/psr/psr-1">English (official)</a>,
+  <a href="/psr/psr-1/es">Spanish</a>,
+  <b>French</b>,
   <a href="/psr/psr-1/it">Italian</a>
 </nav>
 

--- a/psr/psr-1/index.markdown
+++ b/psr/psr-1/index.markdown
@@ -5,9 +5,9 @@ title:  PSR-1 - Basic Coding Standard
 
 <nav id="lngmenu">
   Available translations:
-  <b>English (official)</b>
-  <a href="/psr/psr-1/es">Spanish</a>
-  <a href="/psr/psr-1/fr">French</a>
+  <b>English (official)</b>,
+  <a href="/psr/psr-1/es">Spanish</a>,
+  <a href="/psr/psr-1/fr">French</a>,
   <a href="/psr/psr-1/it">Italian</a>
 </nav>
 

--- a/psr/psr-1/it/index.markdown
+++ b/psr/psr-1/it/index.markdown
@@ -5,9 +5,9 @@ title:  PSR-1 - Basic Coding Standard
 
 <nav id="lngmenu">
   Available translations:
-  <a href="/psr/psr-1">English (official)</a>
-  <a href="/psr/psr-1/es">Spanish</a>
-  <a href="/psr/psr-1/fr">French</a>
+  <a href="/psr/psr-1">English (official)</a>,
+  <a href="/psr/psr-1/es">Spanish</a>,
+  <a href="/psr/psr-1/fr">French</a>,
   <b>Italian</b>
 </nav>
 

--- a/psr/psr-2/es/index.markdown
+++ b/psr/psr-2/es/index.markdown
@@ -5,9 +5,9 @@ title:  PSR-2 - Coding Style Guide
 
 <nav id="lngmenu">
   Available translations:
-  <a href="/psr/psr-2">English (official)</a>
-  <b>Spanish</b>
-  <a href="/psr/psr-2/fr">French</a>
+  <a href="/psr/psr-2">English (official)</a>,
+  <b>Spanish</b>,
+  <a href="/psr/psr-2/fr">French</a>,
   <a href="/psr/psr-2/it">Italian</a>
 </nav>
 

--- a/psr/psr-2/fr/index.markdown
+++ b/psr/psr-2/fr/index.markdown
@@ -5,9 +5,9 @@ title:  PSR-2 - Coding Style Guide
 
 <nav id="lngmenu">
   Available translations:
-  <a href="/psr/psr-2">English (official)</a>
-  <a href="/psr/psr-2/es">Spanish</a>
-  <b>French</b>
+  <a href="/psr/psr-2">English (official)</a>,
+  <a href="/psr/psr-2/es">Spanish</a>,
+  <b>French</b>,
   <a href="/psr/psr-2/it">Italian</a>
 </nav>
 

--- a/psr/psr-2/index.markdown
+++ b/psr/psr-2/index.markdown
@@ -5,9 +5,9 @@ title:  PSR-2 - Coding Style Guide
 
 <nav id="lngmenu">
   Available translations:
-  <b>English (official)</b>
-  <a href="/psr/psr-2/es">Spanish</a>
-  <a href="/psr/psr-2/fr">French</a>
+  <b>English (official)</b>,
+  <a href="/psr/psr-2/es">Spanish</a>,
+  <a href="/psr/psr-2/fr">French</a>,
   <a href="/psr/psr-2/it">Italian</a>
 </nav>
 

--- a/psr/psr-2/it/index.markdown
+++ b/psr/psr-2/it/index.markdown
@@ -5,9 +5,9 @@ title:  PSR-2 - Coding Style Guide
 
 <nav id="lngmenu">
   Available translations:
-  <a href="/psr/psr-2">English (official)</a>
-  <a href="/psr/psr-2/es">Spanish</a>
-  <a href="/psr/psr-2/fr">French</a>
+  <a href="/psr/psr-2">English (official)</a>,
+  <a href="/psr/psr-2/es">Spanish</a>,
+  <a href="/psr/psr-2/fr">French</a>,
   <b>Italian</b>
 </nav>
 

--- a/psr/psr-3/es/index.markdown
+++ b/psr/psr-3/es/index.markdown
@@ -5,8 +5,8 @@ title:  PSR-3 - Logger Interface
 
 <nav id="lngmenu">
   Available translations:
-  <a href="/psr/psr-3">English (official)</a>
-  <b>Spanish</b>
+  <a href="/psr/psr-3">English (official)</a>,
+  <b>Spanish</b>,
   <a href="/psr/psr-3/fr">French</a>
 </nav>
 

--- a/psr/psr-3/fr/index.markdown
+++ b/psr/psr-3/fr/index.markdown
@@ -5,8 +5,8 @@ title:  PSR-3 - Logger Interface
 
 <nav id="lngmenu">
   Available translations:
-  <a href="/psr/psr-3">English (official)</a>
-  <a href="/psr/psr-3/es">Spanish</a>
+  <a href="/psr/psr-3">English (official)</a>,
+  <a href="/psr/psr-3/es">Spanish</a>,
   <b>French</b>
 </nav>
 

--- a/psr/psr-3/index.markdown
+++ b/psr/psr-3/index.markdown
@@ -5,8 +5,8 @@ title:  PSR-3 - Logger Interface
 
 <nav id="lngmenu">
   Available translations:
-  <b>English (official)</b>
-  <a href="/psr/psr-3/es">Spanish</a>
+  <b>English (official)</b>,
+  <a href="/psr/psr-3/es">Spanish</a>,
   <a href="/psr/psr-3/fr">French</a>
 </nav>
 


### PR DESCRIPTION
I have added commas to the language menu to visually separate the options.
