### PR TITLE
use tables extension for redcarpet

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -4,6 +4,8 @@ lsi:       false
 pygments:  true
 permalink: /news/:title/
 markdown:  redcarpet
+redcarpet:
+    extensions: ["tables"]
 
 # custom config
 cachebust: 1


### PR DESCRIPTION
Fixes issue #99

Note: this works locally using jekyll to serve the site, so it should hopefully work on GitHub.
