### PR TITLE
Fix project name and link

### DIFF
--- a/index.md
+++ b/index.md
@@ -206,7 +206,7 @@ Do not combine separate membership requests in a single thread; one request per 
 
     <li>
         <h4>
-            <a target="_blank" href="https://www.wikidata.org">Wikidata</a>
+            <a target="_blank" href="http://www.wikiba.se/">Wikibase</a>
             and <a target="_blank" href="https://semantic-mediawiki.org">Semantic MediaWiki</a>
         </h4>
         Jeroen De Dauw (<a href="https://twitter.com/JeroenDeDauw">@JeroenDeDauw</a>)


### PR DESCRIPTION
The link to Wikidata was wrong, since this is a website, not the software.
Wikibase is to Wikidata what MediaWiki is to Wikipedia.
