### PR TITLE
Remove mention of Packagist.

### DIFF
--- a/index.md
+++ b/index.md
@@ -75,10 +75,7 @@ Do not combine separate membership requests in a single thread; one request per 
     </li>
 
     <li>
-        <h4>
-            <a target="_blank" href="http://getcomposer.org/">Composer</a>
-            and <a target="_blank" href="http://packagist.org/">Packagist</a>
-        </h4>
+        <h4><a target="_blank" href="http://getcomposer.org/">Composer</a></h4>
         Jordi Boggiano (<a href="http://twitter.com/seldaek/">@seldaek</a>)
     </li>
 


### PR DESCRIPTION
Per Jordi's request to normalize everyone to a single project.
