### PR TITLE
added Revive Adserver as member

### DIFF
--- a/index.md
+++ b/index.md
@@ -175,6 +175,11 @@ Do not combine separate membership requests in a single thread; one request per 
     </li>
 
     <li>
+        <h4><a target="_blank" href="http://www.revive-adserver.com/">Revive Adserver</a></h4>
+        Matteo Beccati (<a href="http://twitter.com/mbeccati/">@mbeccati</a>)
+    </li>
+
+    <li>
         <h4><a target="_blank" href="http://sabre.io/">SabreDAV</a></h4>
         Evert Pot (<a href="http://twitter.com/evertp/">@evertp</a>)
     </li>


### PR DESCRIPTION
see https://groups.google.com/d/msg/php-fig/HMTL7V9z5vg/8iOh5olg9hwJ

+1 from PEAR (Brett Bieber)
+1 from Yii (Alexander Makarov)
+1 from concrete5 (Korvin Szanto)
+1 from Contao (Leo Feyer)
+1 from SugarCRM (Filipe Guerra)
+1 from Drupal (Larry Garfield)
+1 from phpDocumentor (Mike van Riel)
+1 from PrestaShop (Rémi Gaillard)
+1 from Community (Cal Evans)
+1 from Sculpin (Beau Simensen)
+1 from Propel (William Durand)
+1 from Assetic (Kris Wallsmith)
+1 from Jackalope (Lukas Kahwe Smith)

13x +1, no -1 and no abstains

by my count, there are currently 36 members, meaning to reach a quorum we need 12 members, which has been reached.
