### PR TITLE
Add configuration for auto-redeploy to get updated TLS certs.

### DIFF
--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -24,6 +24,17 @@ disk: 1024
 hooks:
   build: |
     set -e
+    curl -sS https://platform.sh/cli/installer | php
     gem install bundler
     bin/install.sh
     bin/build.sh
+
+
+crons:
+    renewcert:
+        # Force a redeploy at 6 am (UTC) on the 14th and 28th of every month.
+        spec: '0 6 14,28 * *'
+        cmd: |
+            if [ "$PLATFORM_BRANCH" = master ]; then
+                platform redeploy --yes --no-wait
+            fi


### PR DESCRIPTION
You'll still need to set an API key as an environment variable per https://docs.platform.sh/gettingstarted/cli/api-tokens.html

I have access to do so but IMO it should be setup by the Secretaries so the key is on their account, not mine.  (Or some deploy-only account, which is even better.)