### PR TITLE
Update homepage and fix PSR-18 links

### DIFF
--- a/source/_psr/psr-18-http-client-meta.twig
+++ b/source/_psr/psr-18-http-client-meta.twig
@@ -1,0 +1,11 @@
+---
+psr_number: psr-18
+permalink: /psr/psr-18/meta
+title: 'PSR-18 Meta Document'
+markdown_source: fig-standards/accepted/PSR-18-http-client-meta.md
+related:
+    - { name: 'PSR-18: HTTP Client', permalink: /psr/psr-18/ }
+    - { name: 'PSR-18 Meta Document' }
+---
+
+{{ parent() }}

--- a/source/_psr/psr-18-http-client.twig
+++ b/source/_psr/psr-18-http-client.twig
@@ -1,0 +1,11 @@
+---
+psr_number: psr-18
+permalink: /psr/psr-18/
+title: 'PSR-18: HTTP Client'
+markdown_source: fig-standards/accepted/PSR-18-http-client.md
+related:
+    - { name: 'PSR-18: HTTP Client' }
+    - { name: 'PSR-18 Meta Document', permalink: /psr/psr-18/meta }
+---
+
+{{ parent() }}

--- a/source/_sass/blocks/home_features.scss
+++ b/source/_sass/blocks/home_features.scss
@@ -1,6 +1,6 @@
 .home_features {
 
-    &__item--interfaces {
+    &__item:nth-child(even) {
         background: #f1ede5;
     }
 

--- a/source/index.twig
+++ b/source/index.twig
@@ -110,7 +110,7 @@ interface LoggerInterface
 ~~~php
 <?php
 
-namespace Psr\Log;
+namespace Psr\Http\Message;
 
 /**
  * Representation of an outgoing, client-side request.

--- a/source/index.twig
+++ b/source/index.twig
@@ -108,10 +108,15 @@ interface LoggerInterface
                     <div class="home_features__code">
                         {% filter markdown %}
 ~~~php
-$request = $request
-    ->withMethod('OPTIONS')
-    ->withRequestTarget('*')
-    ->withUri(new Uri('https://example.org/'));
+<?php
+
+namespace Psr\Log;
+
+/**
+ * Representation of an outgoing, client-side request.
+ */
+interface RequestInterface extends MessageInterface
+{
 ~~~
                         {% endfilter %}
                     </div>

--- a/source/index.twig
+++ b/source/index.twig
@@ -90,7 +90,7 @@ interface LoggerInterface
         <li class="home_features__item home_features__item--interfaces">
             <div class="center">
                 <div class="home_features__content">
-                    <h2 class="home_features__title">HTTP Handling</h2>
+                    <h2 class="home_features__title">HTTP</h2>
                     <p class="home_features__description">Interoperable standards and interfaces to have an agnostic approach to handling HTTP requests and responses, both on client and server side.</p>
                     <ul class="home_features__links">
                         <li><a class="home_features__link" href="/psr/psr-7/">PSR-7: HTTP Message Interfaces</a></li>

--- a/source/index.twig
+++ b/source/index.twig
@@ -58,10 +58,8 @@ $object = new ClassName();
                     <ul class="home_features__links">
                         <li><a class="home_features__link" href="/psr/psr-3/">PSR-3: Logger Interface</a></li>
                         <li><a class="home_features__link" href="/psr/psr-6/">PSR-6: Caching Interface</a></li>
-                        <li><a class="home_features__link" href="/psr/psr-7/">PSR-7: HTTP Message Interfaces</a></li>
                         <li><a class="home_features__link" href="/psr/psr-11/">PSR-11: Container Interface</a></li>
                         <li><a class="home_features__link" href="/psr/psr-13/">PSR-13: Hypermedia Links</a></li>
-                        <li><a class="home_features__link" href="/psr/psr-15/">PSR-15: HTTP Handlers</a></li>
                         <li><a class="home_features__link" href="/psr/psr-16/">PSR-16: Simple Cache</a></li>
                     </ul>
                 </div>
@@ -83,6 +81,37 @@ namespace Psr\Log;
  */
 interface LoggerInterface
 {
+~~~
+                        {% endfilter %}
+                    </div>
+                </div>
+            </div>
+        </li>
+        <li class="home_features__item home_features__item--interfaces">
+            <div class="center">
+                <div class="home_features__content">
+                    <h2 class="home_features__title">HTTP Handling</h2>
+                    <p class="home_features__description">Interoperable standards and interfaces to have an agnostic approach to handling HTTP requests and responses, both on client and server side.</p>
+                    <ul class="home_features__links">
+                        <li><a class="home_features__link" href="/psr/psr-7/">PSR-7: HTTP Message Interfaces</a></li>
+                        <li><a class="home_features__link" href="/psr/psr-15/">PSR-15: HTTP Handlers</a></li>
+                        <li><a class="home_features__link" href="/psr/psr-17/">PSR-17: HTTP Factories</a></li>
+                        <li><a class="home_features__link" href="/psr/psr-18/">PSR-18: HTTP Client</a></li>
+                    </ul>
+                </div>
+                <div class="home_features__editor">
+                    <div class="home_features__chrome">
+                        <div class="home_features__chrome_dot"></div>
+                        <div class="home_features__chrome_dot"></div>
+                        <div class="home_features__chrome_dot"></div>
+                    </div>
+                    <div class="home_features__code">
+                        {% filter markdown %}
+~~~php
+$request = $request
+    ->withMethod('OPTIONS')
+    ->withRequestTarget('*')
+    ->withUri(new Uri('https://example.org/'));
 ~~~
                         {% endfilter %}
                     </div>


### PR DESCRIPTION
This PR is to update the homepage. The PSR list was missing the two most recent (PSR 17 & 18) which will complete a nice HTTP-related group of PSRs.

I would like to use this moment to create a new group in the homepage list, and create a separate group for the four HTTP-relate PSR.