### PR TITLE
Port blog inside the site - authors section

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 *.map
 .sass-cache
 .bundle
+app/config/sculpin_kernel_dev.yml

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-ruby '>= 2.3', '< 2.4'
+ruby '>= 2.3', '< 2.6'
 
 gem "sass", "~> 3.5"
 gem "kramdown", "~> 1.15"

--- a/app/config/sculpin_kernel.yml
+++ b/app/config/sculpin_kernel.yml
@@ -42,11 +42,6 @@ services:
   aptoma.twig.markdown_extension:
     class: Aptoma\Twig\Extension\MarkdownExtension
     arguments:
-      $markdownEngine: '@fig.website.michelf_markdown_engine'
-#      $markdownEngine: 'fig.website.external_process_markdown_engine'
+      $markdownEngine: '@fig.website.external_process_markdown_engine'
     tags:
       - { name: twig.extension }
-
-  # used in development, much faster than fig.website.external_process_markdown_engine
-  fig.website.michelf_markdown_engine:
-    class: Aptoma\Twig\Extension\MarkdownEngine\MichelfMarkdownEngine

--- a/app/config/sculpin_kernel.yml
+++ b/app/config/sculpin_kernel.yml
@@ -7,7 +7,6 @@ sculpin_content_types:
     taxonomies:
       - tags
       - categories
-    enabled: true
   pages:
     singular_name: page
     permalink: :basename
@@ -15,8 +14,8 @@ sculpin_content_types:
     path: _pages
   authors:
     singular_name: author
-    permalink: /authors/:basename
-    type: page
+    permalink: authors/:basename
+    type: path
     path: _authors
   psr:
     permalink: psr/:basename

--- a/app/config/sculpin_kernel.yml
+++ b/app/config/sculpin_kernel.yml
@@ -13,6 +13,11 @@ sculpin_content_types:
     permalink: :basename
     type: path
     path: _pages
+  authors:
+    singular_name: author
+    permalink: :basename
+    type: page
+    path: _authors
   psr:
     permalink: psr/:basename
     type: path
@@ -38,6 +43,11 @@ services:
   aptoma.twig.markdown_extension:
     class: Aptoma\Twig\Extension\MarkdownExtension
     arguments:
-      $markdownEngine: '@fig.website.external_process_markdown_engine'
+#      $markdownEngine: '@fig.website.fast'
+      $markdownEngine: 'fig.website.external_process_markdown_engine'
     tags:
       - { name: twig.extension }
+
+  # used in development, much faster than fig.website.external_process_markdown_engine
+  fig.website.michelf_markdown_engine:
+    class: Aptoma\Twig\Extension\MarkdownEngine\MichelfMarkdownEngine

--- a/app/config/sculpin_kernel.yml
+++ b/app/config/sculpin_kernel.yml
@@ -15,7 +15,7 @@ sculpin_content_types:
     path: _pages
   authors:
     singular_name: author
-    permalink: :basename
+    permalink: /authors/:basename
     type: page
     path: _authors
   psr:
@@ -43,8 +43,8 @@ services:
   aptoma.twig.markdown_extension:
     class: Aptoma\Twig\Extension\MarkdownExtension
     arguments:
-#      $markdownEngine: '@fig.website.fast'
-      $markdownEngine: 'fig.website.external_process_markdown_engine'
+      $markdownEngine: '@fig.website.michelf_markdown_engine'
+#      $markdownEngine: 'fig.website.external_process_markdown_engine'
     tags:
       - { name: twig.extension }
 

--- a/app/config/sculpin_kernel_dev.yml.example
+++ b/app/config/sculpin_kernel_dev.yml.example
@@ -1,0 +1,17 @@
+# This enables a faster markdown syntax highlighter to be used on development
+# To enable it, copy this file and name it  "sculpin_kernel_dev.yml"
+
+imports:
+  - sculpin_kernel.yml
+
+services:
+  aptoma.twig.markdown_extension:
+    class: Aptoma\Twig\Extension\MarkdownExtension
+    arguments:
+      $markdownEngine: '@fig.website.michelf_markdown_engine'
+    tags:
+      - { name: twig.extension }
+
+  fig.website.michelf_markdown_engine:
+    class: Aptoma\Twig\Extension\MarkdownEngine\MichelfMarkdownEngine
+    public: false

--- a/source/_authors/alessandro.twig
+++ b/source/_authors/alessandro.twig
@@ -1,0 +1,8 @@
+---
+title: Alessandro Lai
+identifier: alessandrolai
+twitter: AlessandroLai
+avatar: https://www.gravatar.com/avatar/5e9c1c380aa22f2df2f70be07ba35e90?d=404&s=250
+bio: Lead project developer @FacileIt_Engr, @phpfig secretary, @MilanoPHP coordinator, computer science passionate, retired netgaming nerd
+---
+

--- a/source/_authors/alessandro.twig
+++ b/source/_authors/alessandro.twig
@@ -2,7 +2,7 @@
 title: Alessandro Lai
 identifier: alessandrolai
 twitter: AlessandroLai
-avatar: https://www.gravatar.com/avatar/5e9c1c380aa22f2df2f70be07ba35e90?d=404&s=250
+avatar: https://www.gravatar.com/avatar/b4a2877529fa184f0a0b0ba9d6252f70?d=404&s=250
 bio: Lead project developer @FacileIt_Engr, @phpfig secretary, @MilanoPHP coordinator, computer science passionate, retired netgaming nerd
 use:
 - posts

--- a/source/_authors/alessandro.twig
+++ b/source/_authors/alessandro.twig
@@ -4,5 +4,7 @@ identifier: alessandrolai
 twitter: AlessandroLai
 avatar: https://www.gravatar.com/avatar/5e9c1c380aa22f2df2f70be07ba35e90?d=404&s=250
 bio: Lead project developer @FacileIt_Engr, @phpfig secretary, @MilanoPHP coordinator, computer science passionate, retired netgaming nerd
+use:
+- posts
 ---
 

--- a/source/_includes/pagination.twig
+++ b/source/_includes/pagination.twig
@@ -1,12 +1,18 @@
 {% if page.pagination.previous_page or page.pagination.next_page %}
     <ul class="pagination__link">
         {% if page.pagination.previous_page %}
-            <li><a class="pagination__link__new" href="{{ page.pagination.previous_page.url }}">Newer
-                    Posts</a></li>
+            <li>
+                <a class="pagination__link__new" href="{{ page.pagination.previous_page.url }}">
+                    Newer Posts
+                </a>
+            </li>
         {% endif %}
 
         {% if page.pagination.next_page %}
-            <li><a class="pagination__link__old" href="{{ page.pagination.next_page.url }}">Older Posts</a>
+            <li>
+                <a class="pagination__link__old" href="{{ page.pagination.next_page.url }}">
+                    Older Posts
+                </a>
             </li>
         {% endif %}
     </ul>

--- a/source/_includes/pagination.twig
+++ b/source/_includes/pagination.twig
@@ -1,0 +1,13 @@
+{% if page.pagination.previous_page or page.pagination.next_page %}
+    <ul class="pagination__link">
+        {% if page.pagination.previous_page %}
+            <li><a class="pagination__link__new" href="{{ page.pagination.previous_page.url }}">Newer
+                    Posts</a></li>
+        {% endif %}
+
+        {% if page.pagination.next_page %}
+            <li><a class="pagination__link__old" href="{{ page.pagination.next_page.url }}">Older Posts</a>
+            </li>
+        {% endif %}
+    </ul>
+{% endif %}

--- a/source/_includes/post-author.twig
+++ b/source/_includes/post-author.twig
@@ -1,0 +1,34 @@
+<div class="sidebar__author">
+    <h2 class="sidebar__title">Author: {{ author.title }}</h2>
+
+    {% if author.avatar %}
+        <div class="columns__column columns__column--4">
+            <img class="sidebar__author__avatar" src="{{ author.avatar }}" alt=""/>
+        </div>
+    {% endif %}
+
+    {% if author.bio %}
+        <div class="columns__column columns__column--{{ author.avatar ? 8 : 12 }}">
+            <p class="sidebar__description">{{ author.bio }}</p>
+        </div>
+
+    {% endif %}
+
+    <ul class="sidebar__list">
+        {% if author.twitter %}
+            <li class="sidebar__item">
+                <a class="sidebar__link" href="https://twitter.com/{{ author.twitter }}" target="_blank">
+                    @{{ author.twitter }} on Twitter
+                </a>
+            </li>
+        {% endif %}
+
+        <li class="sidebar__item">
+            <a class="sidebar__link" href="{{ author.link }}" target="_blank">
+                More articles from author
+            </a>
+        </li>
+    </ul>
+
+</div>
+

--- a/source/_includes/post-author.twig
+++ b/source/_includes/post-author.twig
@@ -11,7 +11,6 @@
         <div class="columns__column columns__column--{{ author.avatar ? 8 : 12 }}">
             <p class="sidebar__description">{{ author.bio }}</p>
         </div>
-
     {% endif %}
 
     <ul class="sidebar__list">

--- a/source/_includes/post-author.twig
+++ b/source/_includes/post-author.twig
@@ -24,8 +24,8 @@
         {% endif %}
 
         <li class="sidebar__item">
-            <a class="sidebar__link" href="{{ author.url }}" target="_blank">
-                More articles from author
+            <a class="sidebar__link" href="{{ author.url }}">
+                More about author
             </a>
         </li>
     </ul>

--- a/source/_includes/post-author.twig
+++ b/source/_includes/post-author.twig
@@ -24,7 +24,7 @@
         {% endif %}
 
         <li class="sidebar__item">
-            <a class="sidebar__link" href="{{ author.link }}" target="_blank">
+            <a class="sidebar__link" href="{{ author.url }}" target="_blank">
                 More articles from author
             </a>
         </li>

--- a/source/_includes/post-preview.twig
+++ b/source/_includes/post-preview.twig
@@ -1,0 +1,18 @@
+<div class="markdown">
+    <h2>
+        <a class="post__link" href="{{ post.url }}">{{ post.title }}</a>
+    </h2>
+
+    {{ (post.content | markdown|striptags)[0:320] }}...
+
+    <div class="blog-list__meta">
+        <span  class="blog-list__meta__date">
+            {{ post.date|date('F jS Y') }}
+        </span>
+        {% if skipAuthor is empty %}
+        {% for author in data.authors if post.author and author.identifier is same as(post.author) %}
+            - <a class="blog-list__meta__author" href="{{ author.url }}">{{ author.title }}</a>
+        {% endfor %}
+        {% endif %}
+    </div>
+</div>

--- a/source/_includes/post-preview.twig
+++ b/source/_includes/post-preview.twig
@@ -1,4 +1,4 @@
-<div class="markdown">
+<article class="markdown">
     <h2>
         <a class="post__link" href="{{ post.url }}">{{ post.title }}</a>
     </h2>
@@ -17,4 +17,4 @@
 
         {% include 'post-tags.twig' %}
     </div>
-</div>
+</article>

--- a/source/_includes/post-preview.twig
+++ b/source/_includes/post-preview.twig
@@ -3,7 +3,7 @@
         <a class="post__link" href="{{ post.url }}">{{ post.title }}</a>
     </h2>
 
-    {{ (post.content | markdown|striptags)[0:320] }}...
+    {{ (post.content | markdown | striptags)[0:320] }}...
 
     <div class="blog-list__meta">
         <span  class="blog-list__meta__date">

--- a/source/_includes/post-preview.twig
+++ b/source/_includes/post-preview.twig
@@ -10,9 +10,11 @@
             {{ post.date|date('F jS Y') }}
         </span>
         {% if skipAuthor is empty %}
-        {% for author in data.authors if post.author and author.identifier is same as(post.author) %}
-            - <a class="blog-list__meta__author" href="{{ author.url }}">{{ author.title }}</a>
-        {% endfor %}
+            {% for author in data.authors if post.author and author.identifier is same as(post.author) %}
+                - <a class="blog-list__meta__author" href="{{ author.url }}">{{ author.title }}</a>
+            {% endfor %}
         {% endif %}
+
+        {% include 'post-tags.twig' %}
     </div>
 </div>

--- a/source/_includes/post-tags.twig
+++ b/source/_includes/post-tags.twig
@@ -1,0 +1,7 @@
+{% if post.tags %}
+    <div class="post__tags">
+        {% for tag in post.tags %}
+            <a href="/blog/tags/{{ tag|url_encode(true) }}" class="post__tags__tag">{{ tag }}</a>
+        {% endfor %}
+    </div>
+{% endif %}

--- a/source/_layouts/author.twig
+++ b/source/_layouts/author.twig
@@ -1,0 +1,1 @@
+{% extends 'page' %}

--- a/source/_layouts/author.twig
+++ b/source/_layouts/author.twig
@@ -1,1 +1,24 @@
 {% extends 'page' %}
+
+{% block contents %}
+
+    {% if page.avatar %}
+        <img src="{{ page.avatar }}" alt=""/>
+    {% endif %}
+
+    {% if page.bio %}
+        <p class="sidebar__description">{{ page.bio }}</p>
+    {% endif %}
+
+    {% if page.twitter %}
+        <a class="sidebar__link" href="https://twitter.com/{{ page.twitter }}" target="_blank">
+            @{{ page.twitter }} on Twitter
+        </a>
+    {% endif %}
+
+    {% for post in data.posts if post.author and page.identifier == post.author %}
+        {% include 'post-preview.twig' with {skipAuthor: true} %}
+    {% endfor %}
+
+
+{% endblock %}

--- a/source/_layouts/author.twig
+++ b/source/_layouts/author.twig
@@ -2,23 +2,38 @@
 
 {% block contents %}
 
-    {% if page.avatar %}
-        <img src="{{ page.avatar }}" alt=""/>
-    {% endif %}
+    <div class="author">
+        {% if page.avatar %}
+            <div class="columns__column columns__column--2">
+                <img class="author__avatar" src="{{ page.avatar }}" alt=""/>
+            </div>
+        {% endif %}
 
-    {% if page.bio %}
-        <p class="sidebar__description">{{ page.bio }}</p>
-    {% endif %}
-
-    {% if page.twitter %}
-        <a class="sidebar__link" href="https://twitter.com/{{ page.twitter }}" target="_blank">
-            @{{ page.twitter }} on Twitter
-        </a>
-    {% endif %}
-
-    {% for post in data.posts if post.author and page.identifier == post.author %}
-        {% include 'post-preview.twig' with {skipAuthor: true} %}
-    {% endfor %}
+        {% if page.bio %}
+            <div class="columns__column columns__column--4">
+                <p class="author__description">{{ page.bio }}</p>
+            </div>
+        {% endif %}
 
 
+            <div class="columns__column columns__column--4">
+                {% if page.twitter %}
+                    <a class="author__link" href="https://twitter.com/{{ page.twitter }}" target="_blank">
+                        @{{ page.twitter }} on Twitter
+                    </a>
+                {% endif %}
+                {% if page.web %}
+                    <a class="author__link" href="{{ page.web }}" target="_blank">
+                      {{ page.web }}
+                    </a>
+                {% endif %}
+            </div>
+
+        <div class="author__posts">
+            <h2 class="author__posts__subtitle">Articles by {{ page.title }}</h2>
+            {% for post in data.posts if post.author and page.identifier == post.author %}
+                {% include 'post-preview.twig' with {skipAuthor: true} %}
+            {% endfor %}
+        </div>
+    </div>
 {% endblock %}

--- a/source/_layouts/base.twig
+++ b/source/_layouts/base.twig
@@ -3,14 +3,19 @@
 <head>
     <meta charset="utf-8">
     <meta http-equiv="x-ua-compatible" content="ie=edge">
-    {% if page.url == '/' %}
-        <title>{{ page.title }}</title>
-    {% else %}
-        <title>{{ page.title }} - PHP-FIG</title>
-    {% endif %}
+
+    <title>
+        {%- block title -%}
+            {{ page.title }}
+
+            {% if page.url != '/' %}
+                 - PHP-FIG
+            {% endif %}
+        {%- endblock -%}
+    </title>
     <meta name="description" content="We're a group of established PHP projects whose goal is to talk about commonalities between our projects and find ways we can work better together.">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-
+    {% block head_meta %}{% endblock %}
     <link rel="apple-touch-icon" href="/apple-touch-icon.png">
     <!-- Place favicon.ico in the root directory -->
 

--- a/source/_layouts/page.twig
+++ b/source/_layouts/page.twig
@@ -3,7 +3,11 @@
 {% block wrapper %}
 <div class="page_banner">
     <div class="center">
-        <h1 class="page_banner__title">{{ page.title }}</h1>
+        <h1 class="page_banner__title">
+            {% block page_title %}
+            {{ page.title }}
+            {% endblock %}
+        </h1>
     </div>
 </div>
 

--- a/source/_layouts/page.twig
+++ b/source/_layouts/page.twig
@@ -9,7 +9,9 @@
 
 <div class="center">
     <div class="page_content__padding">
-        {{ page.blocks.content | raw }}
+        {% block contents %}
+            {{ page.blocks.content | raw }}
+        {% endblock %}
     </div>
 </div>
 {% endblock %}

--- a/source/_layouts/post.twig
+++ b/source/_layouts/post.twig
@@ -2,11 +2,13 @@
 
 {% block contents %}
 
-
     <div class="columns__column columns__column--8">
         <div class="markdown">
             {{ page.blocks.content| markdown }}
         </div>
+
+        {% include 'post-tags.twig' with {post: page} %}
+
     </div>
 
 

--- a/source/_layouts/post.twig
+++ b/source/_layouts/post.twig
@@ -8,9 +8,7 @@
         </div>
 
         {% include 'post-tags.twig' with {post: page} %}
-
     </div>
-
 
     {% for author in data.authors if page.author and author.identifier == page.author %}
         <div class="columns__column columns__column--4 columns__column--padding_left">

--- a/source/_layouts/post.twig
+++ b/source/_layouts/post.twig
@@ -5,7 +5,7 @@
 
     <div class="columns__column columns__column--8">
         <div class="markdown">
-            {{ page.blocks.content | markdown }}
+            {{ page.blocks.content| markdown }}
         </div>
     </div>
 
@@ -16,6 +16,5 @@
                 {% include 'post-author.twig' %}
             </nav>
         </div>
-
     {% endfor %}
 {% endblock %}

--- a/source/_layouts/post.twig
+++ b/source/_layouts/post.twig
@@ -4,7 +4,9 @@
 
 
     <div class="columns__column columns__column--8">
-        {{ page.blocks.content | raw }}
+        <div class="markdown">
+            {{ page.blocks.content | markdown }}
+        </div>
     </div>
 
 

--- a/source/_layouts/post.twig
+++ b/source/_layouts/post.twig
@@ -10,7 +10,7 @@
     </div>
 
 
-    {% for author in data.authors if author.identifier == page.author %}
+    {% for author in data.authors if page.author and author.identifier == page.author %}
         <div class="columns__column columns__column--4 columns__column--padding_left">
             <nav class="sidebar">
                 {% include 'post-author.twig' %}

--- a/source/_layouts/post.twig
+++ b/source/_layouts/post.twig
@@ -1,5 +1,19 @@
 {% extends 'page' %}
 
-{% block content %}
-TEST
+{% block contents %}
+
+
+    <div class="columns__column columns__column--8">
+        {{ page.blocks.content | raw }}
+    </div>
+
+
+    {% for author in data.authors if author.identifier == page.author %}
+        <div class="columns__column columns__column--4 columns__column--padding_left">
+            <nav class="sidebar">
+                {% include 'post-author.twig' %}
+            </nav>
+        </div>
+
+    {% endfor %}
 {% endblock %}

--- a/source/_pages/blog.twig
+++ b/source/_pages/blog.twig
@@ -14,19 +14,7 @@ use:
             {% include 'post-preview.twig' %}
         {% endfor %}
 
-        {% if page.pagination.previous_page or page.pagination.next_page %}
-
-            <ul class="pagination__link">
-                {% if page.pagination.previous_page %}
-                    <li><a class="pagination__link__new" href="{{ page.pagination.previous_page.url }}">Newer Posts</a></li>
-                {% endif %}
-
-                {% if page.pagination.next_page %}
-                    <li><a class="pagination__link__old" href="{{ page.pagination.next_page.url }}">Older Posts</a></li>
-                {% endif %}
-            </ul>
-
-        {% endif %}
+        {% include 'pagination.twig' %}
     </div>
 
     <div class="columns__column columns__column--4 columns__column--padding_left">

--- a/source/_pages/blog.twig
+++ b/source/_pages/blog.twig
@@ -8,7 +8,7 @@ use:
 - posts
 - authors
 ---
-<div class="columns">
+<div class="columns blog-list">
     <div class="columns__column columns__column--8">
         {% for post in page.pagination.items %}
             {% include 'post-preview.twig' %}

--- a/source/_pages/blog.twig
+++ b/source/_pages/blog.twig
@@ -6,6 +6,7 @@ pagination:
   max_per_page: 1
 use:
 - posts
+- authors
 ---
 <div class="columns">
     <div class="columns__column columns__column--8">
@@ -14,9 +15,35 @@ use:
                 <h2>
                     <a class="post__link" href="{{ post.url }}">{{ post.title }}</a>
                 </h2>
-                {{ post.content | markdown }}
+
+                {{ (post.content | markdown|striptags)[0:320] }}...
+
+                <div class="blog-list__meta">
+                    <span  class="blog-list__meta__date">
+                        {{ post.date|date('F jS Y') }}
+                    </span>
+                    {% for author in data.authors if post.author and author.identifier is same as(post.author) %}
+                         - <a class="blog-list__meta__author" href="{{ author.url }}">{{ author.title }}</a>
+                    {% endfor %}
+                </div>
+
+
             </div>
         {% endfor %}
+
+        {% if page.pagination.previous_page or page.pagination.next_page %}
+
+            <ul class="pagination__link">
+                {% if page.pagination.previous_page %}
+                    <li><a class="pagination__link__new" href="{{ page.pagination.previous_page.url }}">Newer Posts</a></li>
+                {% endif %}
+
+                {% if page.pagination.next_page %}
+                    <li><a class="pagination__link__old" href="{{ page.pagination.next_page.url }}">Older Posts</a></li>
+                {% endif %}
+            </ul>
+
+        {% endif %}
     </div>
 
     <div class="columns__column columns__column--4 columns__column--padding_left">

--- a/source/_pages/blog.twig
+++ b/source/_pages/blog.twig
@@ -11,24 +11,7 @@ use:
 <div class="columns">
     <div class="columns__column columns__column--8">
         {% for post in page.pagination.items %}
-            <div class="markdown">
-                <h2>
-                    <a class="post__link" href="{{ post.url }}">{{ post.title }}</a>
-                </h2>
-
-                {{ (post.content | markdown|striptags)[0:320] }}...
-
-                <div class="blog-list__meta">
-                    <span  class="blog-list__meta__date">
-                        {{ post.date|date('F jS Y') }}
-                    </span>
-                    {% for author in data.authors if post.author and author.identifier is same as(post.author) %}
-                         - <a class="blog-list__meta__author" href="{{ author.url }}">{{ author.title }}</a>
-                    {% endfor %}
-                </div>
-
-
-            </div>
+            {% include 'post-preview.twig' %}
         {% endfor %}
 
         {% if page.pagination.previous_page or page.pagination.next_page %}

--- a/source/_posts/001-a-month-of-php-fig.twig
+++ b/source/_posts/001-a-month-of-php-fig.twig
@@ -1,6 +1,11 @@
 ---
 title: "A month of PHP-FIG #1: October 2017"
 date: 2017-10-30
+author: alessandrolai
+layout: post
+use:
+    - authors
+    - posts
 ---
 As part of the effort to communicate better what’s going on within the PHP-FIG we’re starting a new series of ‘A month of PHP-FIG’ articles to be released towards the end of each month, each being a 2 minute read or less.
 

--- a/source/_posts/001-a-month-of-php-fig.twig
+++ b/source/_posts/001-a-month-of-php-fig.twig
@@ -2,6 +2,7 @@
 title: "A month of PHP-FIG #1: October 2017"
 date: 2017-10-30
 author: alessandrolai
+tags: ['psr', 'monthly']
 layout: post
 use:
     - authors

--- a/source/_posts/2019-05-24-elections.twig
+++ b/source/_posts/2019-05-24-elections.twig
@@ -1,0 +1,35 @@
+---
+title: xxxx
+date: 2017-10-30
+author: alessandrolai
+layout: post
+use:
+    - authors
+    - posts
+---
+
+And we’re back with another update on what’s going on in the PHP-FIG! This time we have just two news, but big ones!
+
+PSR-14 has been approved
+Since the last update, we’ve seen the approval of PSR-14, the Event Dispatcher standard. This new PSR allows packages to rely on a generic interface to dispatch events, without having to write framework-specific code to hook into them.
+
+
+The PSR-14 page on our site
+Apart from reading the spec, you can delve deeper following a fantastic blog series published by the spec’s editor, Larry Garfield:
+
+A major event in PHP
+All about Events
+Being a good Provider
+Advanced Providers
+Compound Providers
+Example — Access voting
+Example — Plugin registration
+Example — Delayed Events, Queues, and Asynchronicity
+Example — PSR-14 in a non-blocking application server
+Example — layered caching
+The May elections
+During May we held a new cycle of elections, as per our bylaws. As in every election there were four Core Committee seats and one Secretary position up for election, plus one additional Core Committee seat due to Lukas Kahwe Smith stepping down early.
+
+At the end of the election, the final result is that we have Asmir Mustafic (@goetas_asmir) as a new secretary, Woody Gilk (@shadowhand) and Matteo Beccati (@mbeccati) as new CC members, and three renewed CC positions (Beau Simensen (@beausimensen), Larry Garfield (@Crell) and Matthew Weier O’Phinney (@mwop)). Congratulations to all of them!
+
+I would also take the occasion to thank the three stepping down members, Margret Staples (@dead_lugosi), Sara Golemon (@SaraMG) and Lukas Kahwe Smith (@lsmith): thank you for all your contributions during these years!

--- a/source/_sass/all.scss
+++ b/source/_sass/all.scss
@@ -25,5 +25,6 @@
 @import "blocks/bylaws";
 @import "blocks/columns";
 @import "blocks/blog";
+@import "blocks/author";
 @import "blocks/sidebar";
 @import "blocks/psr_translation_disclaimer";

--- a/source/_sass/all.scss
+++ b/source/_sass/all.scss
@@ -24,5 +24,6 @@
 @import "blocks/faqs";
 @import "blocks/bylaws";
 @import "blocks/columns";
+@import "blocks/blog";
 @import "blocks/sidebar";
 @import "blocks/psr_translation_disclaimer";

--- a/source/_sass/blocks/author.scss
+++ b/source/_sass/blocks/author.scss
@@ -1,0 +1,82 @@
+.author {
+    &__posts {
+        clear: both;
+
+        &__subtitle {
+            margin: 35px 0;
+            padding: 0 0 5px 0;
+
+            color: #5f5b53;
+            font-family: $titleFont;
+            font-weight: 400;
+            font-size: 22px;
+
+            border-bottom: solid 1px #aaa69d;
+        }
+    }
+
+
+    &__avatar {
+        width: 100%;
+        padding-right: 20px;
+        padding-bottom: 25px;
+        max-width: 250px;
+    }
+    &__description {
+        margin-bottom: 25px;
+
+        color: #595143;
+        font-family: $baseFont;
+        font-size: 15px;
+        line-height: 1.5;
+    }
+
+    &__link {
+        position: relative;
+
+        display: block;
+        padding: 13px 40px 12px 15px;
+
+        color: #f9f6f0;
+        font-family: $baseFont;
+        font-weight: bold;
+        font-size: 15px;
+        text-decoration: none;
+
+        background-color: #aaa69d;
+
+
+        &:after {
+            content: "";
+
+            position: absolute;
+            right: 12px;
+            top: 50%;
+            margin: -11px 0 0 0;
+
+            display: block;
+            width: 20px;
+            height: 23px;
+
+            background: url(/img/arrow_right_brown_icon.png) no-repeat;
+            background-size: cover;
+        }
+
+        &:hover {
+            background-color: lighten(#aaa69d, 5%);
+        }
+    }
+
+    &__link--active {
+        background-color: #f09f47;
+
+        &:after {
+            background-image: url(/img/arrow_right_orange_icon.png);
+        }
+
+        &:hover {
+            background-color: darken(#f09f47, 5%);
+        }
+    }
+
+}

--- a/source/_sass/blocks/blog.scss
+++ b/source/_sass/blocks/blog.scss
@@ -3,13 +3,41 @@
         margin: 25px 0 25px 0;
         padding: 0 0 10px 0;
         border-bottom: solid 1px #aaa69d;
+    }
 
-        &__date {
+    .post__tags  {
+      display: inline;
+      float: right;
 
+      &__tag{
+        display: inline;
+      }
+
+    }
+
+}
+.post{
+    &__tags {
+        a {
+          display: inline-block;
+          margin: 0 5px 5px 0;
+          padding: 5px 8px;
+
+          color: #746a5b;
+          font-family: $baseFont;
+          font-size: 13px;
+          text-decoration: none;
+
+          border-radius: 3px;
+          background: #d4cfc6;
+
+          &:hover {
+            color: white;
+            background: #a39989;
+          }
         }
     }
 }
-
 .pagination{
     &__link a{
         display: inline-block;

--- a/source/_sass/blocks/blog.scss
+++ b/source/_sass/blocks/blog.scss
@@ -1,0 +1,32 @@
+.blog-list {
+    &__meta {
+        margin: 25px 0 25px 0;
+        padding: 0 0 10px 0;
+        border-bottom: solid 1px #aaa69d;
+
+        &__date {
+
+        }
+    }
+}
+
+.pagination{
+    &__link a{
+        display: inline-block;
+        margin: 0 5px 5px 0;
+        padding: 5px 8px;
+
+        color: #746a5b;
+        font-family: $baseFont;
+        font-size: 13px;
+        text-decoration: none;
+
+        border-radius: 3px;
+        background: #d4cfc6;
+
+        &:hover {
+            color: white;
+            background: #a39989;
+        }
+    }
+}

--- a/source/_sass/blocks/sidebar.scss
+++ b/source/_sass/blocks/sidebar.scss
@@ -31,6 +31,21 @@
         line-height: 1.5;
     }
 
+    &__author{
+        &__avatar {
+            width: 100%;
+            padding-right: 20px;
+            padding-bottom: 25px;
+        }
+        .sidebar__description {
+            margin-top: 0;
+        }
+        .sidebar__list {
+            clear: both;
+        }
+    }
+
+
     &__list {
         margin: 25px 0;
     }

--- a/source/blog/tags/tag.twig
+++ b/source/blog/tags/tag.twig
@@ -1,0 +1,46 @@
+---
+layout: page
+title: Tag Archive
+generator: [posts_tag_index, pagination]
+pagination:
+    provider: page.tag_posts
+use:
+- posts_tags
+
+---
+{% block contents %}
+    <div class="columns blog-list">
+        <div class="columns__column columns__column--8">
+            {% for post in page.pagination.items %}
+                {% include 'post-preview.twig' %}
+            {% endfor %}
+
+            {% include 'pagination.twig' %}
+        </div>
+        <div class="columns__column columns__column--4 columns__column--padding_left">
+            <nav class="sidebar">
+                <h2 class="sidebar__title">Other tags:</h2>
+                <ul class="sidebar__list">
+                    {% for tag,posts in data.posts_tags %}
+                        <li class="sidebar__item">
+                            <a class="sidebar__link {% if page.url == '/blog/tags/' ~ (tag|url_encode(true))~'/' %}sidebar__link--active{% endif %}"
+                               href="/blog/tags/{{ tag|url_encode(true) }}">{{ tag }} ({{ posts|length }})</a>
+                        </li>
+                    {% endfor %}
+                </ul>
+            </nav>
+        </div>
+    </div>
+{% endblock %}
+
+{% block head_meta %}
+    <meta name="robots" content="noindex, follow">
+{% endblock %}
+
+{%- block title -%}
+    {{ page.tag }} - {{ parent() }}
+{%- endblock -%}
+
+ {% block page_title %}
+     {{ page.title }}: {{ page.tag }}
+ {% endblock %}


### PR DESCRIPTION
This  PR adds some features for https://github.com/php-fig/www.php-fig.org/pull/258

- authors section on article page
- article meta on list articles page
- pagination links on articles page
- author page
- other minor fixes

More additions will come in the next days.

My CSS abilities are quite low :smile: 

post page:

![image](https://user-images.githubusercontent.com/776743/58752690-21f60480-84bc-11e9-88f4-08c5505a389a.png)

post meta (on blog list page): 
![image](https://user-images.githubusercontent.com/776743/58753229-ad739380-84c4-11e9-99fc-4e95abb77bbf.png)

author page:
![image](https://user-images.githubusercontent.com/776743/58759131-d0865d80-852d-11e9-8d32-0b10cea06d7c.png)

tags support:

![image](https://user-images.githubusercontent.com/776743/58759348-198be100-8531-11e9-8660-5303aea79f2d.png)


singe tag and tag-cloud page:

![image](https://user-images.githubusercontent.com/776743/58786784-05a7b400-85f1-11e9-80ea-36889d63c92b.png)
