### PR TITLE
Improve author css

### DIFF
--- a/source/_authors/alessandro.twig
+++ b/source/_authors/alessandro.twig
@@ -1,6 +1,7 @@
 ---
 title: Alessandro Lai
 identifier: alessandrolai
+web: https://alessandrolai.dev
 twitter: AlessandroLai
 avatar: https://www.gravatar.com/avatar/b4a2877529fa184f0a0b0ba9d6252f70?d=404&s=250
 bio: Lead project developer @FacileIt_Engr, @phpfig secretary, @MilanoPHP coordinator, computer science passionate, retired netgaming nerd

--- a/source/_includes/post-author.twig
+++ b/source/_includes/post-author.twig
@@ -1,14 +1,14 @@
 <div class="sidebar__author">
     <h2 class="sidebar__title">Author: {{ author.title }}</h2>
 
-    {% if author.avatar %}
-        <div class="columns__column columns__column--4">
-            <img class="sidebar__author__avatar" src="{{ author.avatar }}" alt="{{ author.title }}'s avatar"/>
-        </div>
-    {% endif %}
-
     {% if author.bio %}
-        <div class="columns__column columns__column--{{ author.avatar ? 8 : 12 }}">
+        <div class="columns__column columns__column--12">
+            {% if author.avatar %}
+                <div class="columns__column columns__column--4">
+                    <img class="sidebar__author__avatar" src="{{ author.avatar }}" alt="{{ author.title }}'s avatar"/>
+                </div>
+            {% endif %}
+
             <p class="sidebar__description">{{ author.bio }}</p>
         </div>
     {% endif %}

--- a/source/_layouts/author.twig
+++ b/source/_layouts/author.twig
@@ -24,7 +24,7 @@
                 {% endif %}
                 {% if page.web %}
                     <a class="author__link" href="{{ page.web }}" target="_blank">
-                      {{ page.web }}
+                      Site: {{ page.web }}
                     </a>
                 {% endif %}
             </div>

--- a/source/_sass/blocks/author.scss
+++ b/source/_sass/blocks/author.scss
@@ -23,6 +23,7 @@
         max-width: 250px;
     }
     &__description {
+        margin-right: 25px;
         margin-bottom: 25px;
 
         color: #595143;
@@ -36,6 +37,7 @@
 
         display: block;
         padding: 13px 40px 12px 15px;
+        margin-bottom: 0.8em;
 
         color: #f9f6f0;
         font-family: $baseFont;

--- a/source/_sass/blocks/sidebar.scss
+++ b/source/_sass/blocks/sidebar.scss
@@ -34,8 +34,9 @@
     &__author{
         &__avatar {
             width: 100%;
-            padding-right: 20px;
-            padding-bottom: 25px;
+            padding-right: 1em;
+            padding-bottom: 0.5em;
+            padding-top: 0.3em;
         }
         .sidebar__description {
             margin-top: 0;


### PR DESCRIPTION
This improves a bit the appearance of the author on the post and on the dedicated page.

From this:

![immagine](https://user-images.githubusercontent.com/6729988/66144802-d4c0a580-e609-11e9-8541-9b644ef96592.png)

to this:

![immagine](https://user-images.githubusercontent.com/6729988/66144833-e1dd9480-e609-11e9-8b9b-e558713134ee.png)

and from this:

![immagine](https://user-images.githubusercontent.com/6729988/66144912-ffaaf980-e609-11e9-823c-a03866b88e42.png)

to this:

![immagine](https://user-images.githubusercontent.com/6729988/66144931-089bcb00-e60a-11e9-8633-b8681f5afb3b.png)
