### PR TITLE
Add post date on the bottom of the post page

### DIFF
--- a/source/_layouts/post.twig
+++ b/source/_layouts/post.twig
@@ -8,6 +8,10 @@
         </div>
 
         {% include 'post-tags.twig' with {post: page} %}
+
+        <span  class="blog-post__meta__date">
+            {{ page.date|date('F jS Y') }}
+        </span>
     </div>
 
     {% for author in data.authors if page.author and author.identifier == page.author %}

--- a/source/_sass/all.scss
+++ b/source/_sass/all.scss
@@ -10,6 +10,7 @@
 @import "base/center";
 
 // Blocks
+@import "blocks/blog_post";
 @import "blocks/site_header";
 @import "blocks/site_logo";
 @import "blocks/site_menu";

--- a/source/_sass/blocks/blog_post.scss
+++ b/source/_sass/blocks/blog_post.scss
@@ -1,0 +1,10 @@
+.blog-post {
+    &__meta__date {
+        color: #595143;
+        font-family: $baseFont;
+        font-size: 18px;
+        margin-bottom: 2em;
+        display: block;
+    }
+
+}


### PR DESCRIPTION
Preview on how it looks on the bottom of the page.

![image](https://user-images.githubusercontent.com/776743/67127541-e1442100-f1f9-11e9-9c2a-48ab0d9d534e.png)


I tried to add it on the top, but since almost all the posts starts with some subtitle, the date does not fit at all...

Preview at http://www---pr-268-43namgq-ovkfaqrdltr5s.us.platform.sh/