### PR TITLE
Update PHP & Ruby

### DIFF
--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -1,5 +1,5 @@
 name: php-fig-website
-type: php:7.4
+type: php:8.0
 
 build:
   flavor: composer

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source "https://rubygems.org"
 
-ruby '>= 2.3', '< 2.4'
+ruby '>= 2.5', '< 2.6'
 
-gem "html-proofer", "~> 3.7"
+gem "html-proofer", "~> 3.19"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,10 +3,10 @@ GEM
   specs:
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
-    ethon (0.12.0)
-      ffi (>= 1.3.0)
-    ffi (1.11.3)
-    html-proofer (3.15.0)
+    ethon (0.14.0)
+      ffi (>= 1.15.0)
+    ffi (1.15.0)
+    html-proofer (3.19.1)
       addressable (~> 2.3)
       mercenary (~> 0.3)
       nokogumbo (~> 2.0)
@@ -14,27 +14,29 @@ GEM
       rainbow (~> 3.0)
       typhoeus (~> 1.3)
       yell (~> 2.0)
-    mercenary (0.3.6)
-    mini_portile2 (2.4.0)
-    nokogiri (1.10.8)
-      mini_portile2 (~> 2.4.0)
-    nokogumbo (2.0.2)
+    mercenary (0.4.0)
+    mini_portile2 (2.5.0)
+    nokogiri (1.11.3)
+      mini_portile2 (~> 2.5.0)
+      racc (~> 1.4)
+    nokogumbo (2.0.5)
       nokogiri (~> 1.8, >= 1.8.4)
-    parallel (1.19.1)
-    public_suffix (4.0.1)
+    parallel (1.20.1)
+    public_suffix (4.0.6)
+    racc (1.5.2)
     rainbow (3.0.0)
-    typhoeus (1.3.1)
+    typhoeus (1.4.0)
       ethon (>= 0.9.0)
-    yell (2.2.0)
+    yell (2.2.2)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  html-proofer (~> 3.7)
+  html-proofer (~> 3.19)
 
 RUBY VERSION
-   ruby 2.3.8p459
+   ruby 2.5.9p229
 
 BUNDLED WITH
    1.17.3

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -15,9 +15,7 @@ GEM
       typhoeus (~> 1.3)
       yell (~> 2.0)
     mercenary (0.4.0)
-    mini_portile2 (2.5.0)
-    nokogiri (1.11.3)
-      mini_portile2 (~> 2.5.0)
+    nokogiri (1.11.3-x86_64-linux)
       racc (~> 1.4)
     nokogumbo (2.0.5)
       nokogiri (~> 1.8, >= 1.8.4)
@@ -30,7 +28,7 @@ GEM
     yell (2.2.2)
 
 PLATFORMS
-  ruby
+  x86_64-linux
 
 DEPENDENCIES
   html-proofer (~> 3.19)
@@ -39,4 +37,4 @@ RUBY VERSION
    ruby 2.5.9p229
 
 BUNDLED WITH
-   1.17.3
+   2.2.16

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Additionally, you can run `make html-proofer` to run the same checks that are ru
 Note that:
 - you can open a shell inside the PHP container with `make shell`
 - inside the PHP container, relevant executables are in the global `PATH`
-- the container is executed with user and group with id `1000` by default, which will likely match your main host user. You can change the id via the `UID` and `GID` build-time variables; you can configure those locally creating a `docker-compose.override.yml` (which is ignored by Git) containing:
+- the containers are executed with user and group with id `1000` by default, which will likely match your main host user. You can change the id via the `UID` and `GID` build-time variables; you can configure those locally creating a `docker-compose.override.yml` (which is ignored by Git) containing:
 ```yaml
 version: '3.5'
 

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "fig/www.php-fig.org",
     "description": "The static official site of PHP-FIG",
     "require": {
-        "php": "^7.4",
+        "php": "^8.0",
         "aptoma/twig-markdown": "^3.3",
         "league/commonmark": "^1.4",
         "sculpin/sculpin": "^3.0.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "93f4dd39a6a424cda51eb8cb353e7448",
+    "content-hash": "65d42ff77819451ba945d5c14faceade",
     "packages": [
         {
             "name": "aptoma/twig-markdown",
@@ -3733,7 +3733,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^7.4"
+        "php": "^8.0"
     },
     "platform-dev": [],
     "plugin-api-version": "2.0.0"

--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.4.16-fpm-alpine3.13
+FROM php:8.0.3-cli-alpine3.13
 
 RUN apk add --no-cache \
         bash \

--- a/docker/ruby/Dockerfile
+++ b/docker/ruby/Dockerfile
@@ -6,3 +6,12 @@ RUN apk add --no-cache \
         libffi-dev \
         libzip-dev \
         zip
+
+# setup user
+ARG UID=1000
+ARG GID=1000
+RUN addgroup -g $GID fig && adduser -D -G fig -u $UID fig
+USER fig
+
+# update to bundler 2.0
+RUN gem install bundler:2

--- a/docker/ruby/Dockerfile
+++ b/docker/ruby/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.3-alpine3.7
+FROM ruby:2.5-alpine3.13
 
 RUN apk add --no-cache \
         build-base \


### PR DESCRIPTION
This will update PHP to 8.0, and in turn this will unlock Ruby 2.5 in the build process. This will allow us to update HTML-Proofer to the latest version overcoming the [security advisory about nokogiri 1.10](https://github.com/sparklemotion/nokogiri/security/advisories/GHSA-vr8q-g5c7-m54m).