### PR TITLE
Adds basic atom feed + atom/xml link

### DIFF
--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -16,7 +16,7 @@ web:
       scripts: true
       allow: false
       rules:
-        \.(css|js|gif|jpe?g|png|ttf|eot|woff2?|otf|html|ico|svg?)$:
+        \.(css|js|gif|jpe?g|png|ttf|eot|woff2?|otf|html|ico|xml|svg?)$:
           allow: true
         ^/(robots|humans)\.txt$:
           allow: true

--- a/source/_layouts/base.twig
+++ b/source/_layouts/base.twig
@@ -24,6 +24,8 @@
     <link rel="preconnect" href="https://ajax.googleapis.com" pr="1.0" />
     <link rel="preconnect" href="https://ssl.google-analytics.com" pr="0.8" />
 
+    <link rel="alternate" type="application/atom+xml" href="/atom.xml" title="PHP-FIG Blog Feed" />
+
     <meta name="og:title" content="{{ block('title') |replace({"\n": ''}) | trim }}" />
 
     <meta name="twitter:title" content="{{ block('title') |replace({"\n": ''}) | trim }}" />

--- a/source/atom.xml
+++ b/source/atom.xml
@@ -21,7 +21,7 @@ use:
             <link href="{{ site.host }}{{ post.url }}"/>
             <updated>{{ post.date|date('c') }}</updated>
             <id>{{ site.host }}{{ post.url }}</id>
-            <content type="html"><![CDATA[{{ post.blocks.content|raw }}]]></content>
+            <content type="html"><![CDATA[{{ post.blocks.content|striptags('<p><br><em><strong><blockquote><ul><ol><li><img><pre><code><a><h1><h2><h3><h4><h5><h6>')|raw }}]]></content>
 
             {% for author in data.authors if post.author and author.identifier is same as(post.author) %}
             <author>

--- a/source/atom.xml
+++ b/source/atom.xml
@@ -1,0 +1,35 @@
+---
+permalink: atom.xml
+use:
+- authors
+- posts
+---
+<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+    <title>PHP-FIG Blog Feed</title>
+    <link href="{{ site.host }}/atom.xml" rel="self"/>
+    <link href="{{ site.host }}/"/>
+    <author>
+        <name>PHP-FIG</name>
+    </author>
+    <updated>{{ site.calculated_date | date('c') }}</updated>
+    <id>{{ site.host }}/</id>
+
+    {% for post in data.posts %}
+        <entry>
+            <title type="html"><![CDATA[{{ post.title }}]]></title>
+            <link href="{{ site.host }}{{ post.url }}"/>
+            <updated>{{ post.date|date('c') }}</updated>
+            <id>{{ site.host }}{{ post.url }}</id>
+            <content type="html"><![CDATA[{{ post.blocks.content|raw }}]]></content>
+
+            {% for author in data.authors if post.author and author.identifier is same as(post.author) %}
+            <author>
+                <name><![CDATA[{{ author.title }}]]></name>
+                <uri>{{ site.host }}{{ author.url }}</uri>
+            </author>
+            {% endfor %}
+
+        </entry>
+    {% endfor %}
+</feed>


### PR DESCRIPTION
Adds a basic atom feed for the blog and a global `<link>`

I do believe this solves #251

It produces a syntactically valid ATOM feed 

![image](https://user-images.githubusercontent.com/133747/124699847-3d107b00-deb1-11eb-8253-592e4a7f5d07.png)
