### PR TITLE
Change Docker configuration to use Debian Buster instead of Alpine to have proper iconv support

### DIFF
--- a/bin/build-php.sh
+++ b/bin/build-php.sh
@@ -2,4 +2,4 @@
 
 set -e
 
-vendor/bin/sculpin generate -n --clean
+sculpin generate -n --clean

--- a/bin/build-php.sh
+++ b/bin/build-php.sh
@@ -2,4 +2,4 @@
 
 set -e
 
-sculpin generate -n --clean
+vendor/sculpin/sculpin/bin/sculpin generate -n --clean

--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -1,12 +1,10 @@
-FROM php:8.0.3-cli-alpine3.13
+FROM php:8.0-cli
 
-RUN apk add --no-cache \
-        bash \
-        zip
+RUN apt-get update && apt-get install -y \
+    bash \
+    unzip \
+    && rm -rf /var/lib/apt/lists/*
 
-# workaround for https://github.com/docker-library/php/issues/240
-RUN apk add --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/community/ gnu-libiconv
-ENV LD_PRELOAD /usr/lib/preloadable_libiconv.so php
 
 RUN curl -sSL https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 
@@ -15,7 +13,8 @@ ENV PATH /fig-website/bin:/fig-website/vendor/sculpin/sculpin/bin:/fig-website/v
 # setup user
 ARG UID=1000
 ARG GID=1000
-RUN addgroup -g $GID fig && adduser -D -G fig -u $UID fig \
+RUN addgroup --gid $GID fig \
+    && adduser --disabled-password --ingroup fig --uid $UID fig \
     && mkdir /fig-website \
     && chown fig:fig /fig-website
 WORKDIR /fig-website

--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -10,7 +10,7 @@ ENV LD_PRELOAD /usr/lib/preloadable_libiconv.so php
 
 RUN curl -sSL https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 
-ENV PATH /fig-website/bin:/fig-website/vendor/bin:${PATH}
+ENV PATH /fig-website/bin:/fig-website/vendor/sculpin/sculpin/bin:/fig-website/vendor/bin:${PATH}
 
 # setup user
 ARG UID=1000


### PR DESCRIPTION
I had two problems while running the Docker based dev environment:
- Alpine's `iconv` support is not complete and does not support `//TRANSLIT`
- Composer on Docker on WSL creates bad proxy files in `vendor/bin`, I've bypassed those