### PR TITLE
Reduce names on PSR index

### DIFF
--- a/source/_pages/psr.twig
+++ b/source/_pages/psr.twig
@@ -2,7 +2,7 @@
 title: PHP Standards Recommendations
 ---
 
-<div class="markdown">
+<div class="markdown psr_index">
     {% set index = include('fig-standards/PSR.md') %}
     {{ index | processLinks | markdown }}
 </div>

--- a/source/_psr/psr-0-meta.twig
+++ b/source/_psr/psr-0-meta.twig
@@ -4,7 +4,7 @@ permalink: /psr/psr-0/meta
 title: 'PSR-0 Meta Document'
 markdown_source: fig-standards/accepted/PSR-0.md
 related:
-    - { name: 'PSR-0: Autoloading Standard', permalink: /psr/psr-0/ }
+    - { name: 'PSR-0: Autoloading Standard (deprecated)', permalink: /psr/psr-0/ }
     - { name: 'PSR-4: Autoloading Standard', permalink: /psr/psr-4/ }
     - { name: 'PSR-0 Meta Document' }
 ---

--- a/source/_psr/psr-0-meta.twig
+++ b/source/_psr/psr-0-meta.twig
@@ -1,0 +1,12 @@
+---
+psr_number: psr-0
+permalink: /psr/psr-0/meta
+title: 'PSR-0 Meta Document'
+markdown_source: fig-standards/accepted/PSR-0.md
+related:
+    - { name: 'PSR-0: Autoloading Standard', permalink: /psr/psr-0/ }
+    - { name: 'PSR-4: Autoloading Standard', permalink: /psr/psr-4/ }
+    - { name: 'PSR-0 Meta Document' }
+---
+
+{{ parent() }}

--- a/source/_psr/psr-0.twig
+++ b/source/_psr/psr-0.twig
@@ -6,7 +6,7 @@ markdown_source: fig-standards/accepted/PSR-0.md
 related:
     - { name: 'PSR-0: Autoloading Standard' }
     - { name: 'PSR-4: Autoloading Standard', permalink: /psr/psr-4/ }
-    - { name: 'PSR-0 Meta Document', permalink: /psr/psr-1/meta }
+    - { name: 'PSR-0 Meta Document', permalink: /psr/psr-0/meta }
 ---
 
 {{ parent() }}

--- a/source/_psr/psr-0.twig
+++ b/source/_psr/psr-0.twig
@@ -5,6 +5,8 @@ title: 'PSR-0: Autoloading Standard'
 markdown_source: fig-standards/accepted/PSR-0.md
 related:
     - { name: 'PSR-0: Autoloading Standard' }
+    - { name: 'PSR-4: Autoloading Standard', permalink: /psr/psr-4/ }
+    - { name: 'PSR-0 Meta Document', permalink: /psr/psr-1/meta }
 ---
 
 {{ parent() }}

--- a/source/_psr/psr-1-basic-coding-standard-meta.twig
+++ b/source/_psr/psr-1-basic-coding-standard-meta.twig
@@ -1,0 +1,11 @@
+---
+psr_number: psr-1
+permalink: /psr/psr-1/meta
+title: 'PSR-1 Meta Document'
+markdown_source: fig-standards/accepted/PSR-1-basic-coding-standard-meta.md
+related:
+    - { name: 'PSR-1: Basic Coding Standard', permalink: /psr/psr-1/ }
+    - { name: 'PSR-1 Meta Document' }
+---
+
+{{ parent() }}

--- a/source/_psr/psr-1-basic-coding-standard.twig
+++ b/source/_psr/psr-1-basic-coding-standard.twig
@@ -5,6 +5,7 @@ title: 'PSR-1: Basic Coding Standard'
 markdown_source: fig-standards/accepted/PSR-1-basic-coding-standard.md
 related:
     - { name: 'PSR-1: Basic Coding Standard' }
+    - { name: 'PSR-1 Meta Document', permalink: /psr/psr-1/meta }
 ---
 
 {{ parent() }}

--- a/source/_psr/psr-12-extended-coding-style-meta.twig
+++ b/source/_psr/psr-12-extended-coding-style-meta.twig
@@ -5,6 +5,7 @@ title: 'PSR-12: Extended Coding Style'
 markdown_source: fig-standards/accepted/PSR-12-extended-coding-style-guide-meta.md
 related:
     - { name: 'PSR-12: Extended Coding Style', permalink: /psr/psr-12/ }
+    - { name: 'PER Coding Style: /per/coding-style/ }
     - { name: 'PSR-12 Meta Document' }
 ---
 

--- a/source/_psr/psr-12-extended-coding-style.twig
+++ b/source/_psr/psr-12-extended-coding-style.twig
@@ -5,6 +5,7 @@ title: 'PSR-12: Extended Coding Style'
 markdown_source: fig-standards/accepted/PSR-12-extended-coding-style-guide.md
 related:
     - { name: 'PSR-12: Extended Coding Style' }
+    - { name: 'PER Coding Style: /per/coding-style/ }
     - { name: 'PSR-12 Meta Document', permalink: /psr/psr-12/meta }
 ---
 

--- a/source/_psr/psr-2-coding-style-guide-meta.twig
+++ b/source/_psr/psr-2-coding-style-guide-meta.twig
@@ -6,6 +6,7 @@ markdown_source: fig-standards/accepted/PSR-2-coding-style-guide-meta.md
 related:
     - { name: 'PSR-2: Coding Style Guide', permalink: /psr/psr-2/ }
     - { name: 'PSR-12: Extended Coding Style', permalink: /psr/psr-12/ }
+    - { name: 'PER Coding Style: /per/coding-style/ }
     - { name: 'PSR-2 Meta Document' }
 ---
 

--- a/source/_psr/psr-2-coding-style-guide-meta.twig
+++ b/source/_psr/psr-2-coding-style-guide-meta.twig
@@ -5,6 +5,7 @@ title: 'PSR-2 Meta Document'
 markdown_source: fig-standards/accepted/PSR-2-coding-style-guide-meta.md
 related:
     - { name: 'PSR-2: Coding Style Guide', permalink: /psr/psr-2/ }
+    - { name: 'PSR-12: Extended Coding Style', permalink: /psr/psr-12/ }
     - { name: 'PSR-2 Meta Document' }
 ---
 

--- a/source/_psr/psr-2-coding-style-guide.twig
+++ b/source/_psr/psr-2-coding-style-guide.twig
@@ -6,6 +6,7 @@ markdown_source: fig-standards/accepted/PSR-2-coding-style-guide.md
 related:
     - { name: 'PSR-2: Coding Style Guide' }
     - { name: 'PSR-12: Extended Coding Style', permalink: /psr/psr-12/ }
+    - { name: 'PER Coding Style: /per/coding-style/ }
     - { name: 'PSR-2 Meta Document', permalink: /psr/psr-2/meta }
 ---
 

--- a/source/_psr/psr-2-coding-style-guide.twig
+++ b/source/_psr/psr-2-coding-style-guide.twig
@@ -5,6 +5,7 @@ title: 'PSR-2: Coding Style Guide'
 markdown_source: fig-standards/accepted/PSR-2-coding-style-guide.md
 related:
     - { name: 'PSR-2: Coding Style Guide' }
+    - { name: 'PSR-12: Extended Coding Style', permalink: /psr/psr-12/ }
     - { name: 'PSR-2 Meta Document', permalink: /psr/psr-2/meta }
 ---
 

--- a/source/_sass/all.scss
+++ b/source/_sass/all.scss
@@ -29,3 +29,4 @@
 @import "blocks/author";
 @import "blocks/sidebar";
 @import "blocks/psr_translation_disclaimer";
+@import "blocks/psr_index";

--- a/source/_sass/blocks/psr_index.scss
+++ b/source/_sass/blocks/psr_index.scss
@@ -1,0 +1,8 @@
+.psr_index {
+  table tbody tr td:first-of-type {
+    width: 5%;
+  }
+  table tbody tr td:nth-of-type(2)  {
+    min-width: 40%;
+  }
+}


### PR DESCRIPTION
- Editors become maintainers after PSR is accepted, updated labels
- Move credits of past contributors to meta files, to reduce clutter
- Add meta file for PSR-0 and PSR-1
- Reference new PSR for PSR-0 and PSR-2

See also php-fig/fig-standards#1268, which is a pre-requisite for this PR (submodule)