### PR TITLE
Fixes & easier local dev

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source "https://rubygems.org"
 
-ruby '>= 2.5', '< 2.6'
+ruby '>= 2.5', '< 2.7'
 
 gem "html-proofer", "~> 3.19"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -15,6 +15,10 @@ GEM
       typhoeus (~> 1.3)
       yell (~> 2.0)
     mercenary (0.4.0)
+    mini_portile2 (2.6.1)
+    nokogiri (1.12.5)
+      mini_portile2 (~> 2.6.1)
+      racc (~> 1.4)
     nokogiri (1.12.5-x86_64-linux)
       racc (~> 1.4)
     nokogumbo (2.0.5)
@@ -28,6 +32,7 @@ GEM
     yell (2.2.2)
 
 PLATFORMS
+  aarch64-linux
   x86_64-linux
 
 DEPENDENCIES
@@ -37,4 +42,4 @@ RUBY VERSION
    ruby 2.5.9p229
 
 BUNDLED WITH
-   2.2.16
+   2.3.26

--- a/Makefile
+++ b/Makefile
@@ -19,3 +19,6 @@ html-proofer:
 
 shell:
 	@docker-compose run --rm php bash
+
+update-sub-modules:
+	git submodule sync && git submodule update --init --remote --force

--- a/bin/build-sass.sh
+++ b/bin/build-sass.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-node-sass \
+npx --yes node-sass \
   --output-style=compressed \
   source/_sass/all.scss \
-  output_dev/css/all.css
+  output_dev/css/all.css || true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,14 +31,10 @@ services:
     entrypoint: 'sh'
 
   node-sass:
-    image: catchdigital/node-sass:8.12.0-alpine
+    image: node:16-alpine
     user: 1000:1000
     working_dir: /fig-website
     volumes:
       - .:/fig-website
     command:
-      - 'node-sass'
-      - '--output-style=compressed'
-      - '--watch'
-      - 'source/_sass/all.scss'
-      - 'output_dev/css/all.css'
+      - ./bin/build-sass.sh

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,7 @@ services:
 
   ruby:
     build:
-      context: docker/ruby
+      context: ruby:2.7-alpine
     user: 1000:1000
     working_dir: /fig-website
     volumes:


### PR DESCRIPTION
This just updates a few things.

- Documents ruby using wider version range (Still messes with my RVM, confirmed 2.7.6 works)
- Updates node-sass docker-image and command(s) to run for M1 chip support
- Adds makefile target to update the sub-modules