### PR TITLE
Update PER-CS to v2.0.0

### DIFF
--- a/source/_per/coding-style.twig
+++ b/source/_per/coding-style.twig
@@ -1,6 +1,6 @@
 ---
 permalink: /per/coding-style
-title: 'PER Coding Style'
+title: 'PER Coding Style 2.0'
 markdown_source: per-coding-style/spec.md
 related:
     - { name: 'PER Coding Style' }


### PR DESCRIPTION
This PR updates the `per-coding-style` to the latest version. This method of managing the current version of PER-CS is a bit dangerous because we actively modify the master branch between versions so it might be good to lock this to tags somehow.