### PR TITLE
Update Crell's bio

### DIFF
--- a/source/_authors/crell.twig
+++ b/source/_authors/crell.twig
@@ -1,9 +1,8 @@
 ---
 title: Larry Garfield
 identifier: crell
-twitter: Crell
 avatar: /img/blog/avatars/larry-garfield.jpg
-bio: Larry Garfield is an aspiring blacksmith who moonlights as Director of Developer Experience for Platform.sh.  Since 2017 he has been a member of the PHP-FIG Core Committee. PSR-8 compatible.
+bio: Larry Garfield is an aspiring blacksmith who moonlights as a Staff Engineer for LegalZoom.  Since 2017 he has been a member of the PHP-FIG Core Committee. PSR-8 compatible.
 use:
 - posts
 ---


### PR DESCRIPTION
This bio is several years out of date. 😄  We should also add support for linking to Mastodon, not just Twitter, on the bio pages.