### PR TITLE
Harden external author links

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ This is the source for [www.php-fig.org][php-fig.org]. It is a static site gener
  - If you notice something missing, please [open an issue on GitHub][issue].
 
  - If you'd like to fix it yourself, simply [edit the file on GitHub][edit] and
-    open a pull request. The site will be recompiled in preview as soon as open it.
+    open a pull request. The site will be recompiled in preview as soon as you open it.
 
- - If you'd like to run the site locally o generate the HTML files, you'll need to install the dependencies.
+ - If you'd like to run the site locally or generate the HTML files, you'll need to install the dependencies.
     The templates are built by directly including the Markdown sources from the [fig standards repo][fig-standards], which is provided as a git submodule.
 
     [issue]: https://github.com/php-fig/www.php-fig.org/issues

--- a/source/_includes/post-author.twig.html
+++ b/source/_includes/post-author.twig.html
@@ -16,7 +16,7 @@
     <ul class="sidebar__list">
         {% if author.twitter %}
             <li class="sidebar__item">
-                <a class="sidebar__link" href="https://twitter.com/{{ author.twitter }}" target="_blank">
+                <a class="sidebar__link" href="https://twitter.com/{{ author.twitter }}" target="_blank" rel="noopener noreferrer">
                     @{{ author.twitter }} on Twitter
                 </a>
             </li>
@@ -24,7 +24,7 @@
 
         {% if author.mastodon %}
             <li class="sidebar__item">
-                <a class="sidebar__link" href="{{ author.mastodon }}" target="_blank">
+                <a class="sidebar__link" href="{{ author.mastodon }}" target="_blank" rel="noopener noreferrer">
                     {{ author.mastodon }} on Mastodon
                 </a>
             </li>

--- a/source/_layouts/author.twig.html
+++ b/source/_layouts/author.twig.html
@@ -18,17 +18,17 @@
 
             <div class="columns__column columns__column--4">
                 {% if page.twitter %}
-                    <a class="author__link" href="https://twitter.com/{{ page.twitter }}" target="_blank">
+                    <a class="author__link" href="https://twitter.com/{{ page.twitter }}" target="_blank" rel="noopener noreferrer">
                         @{{ page.twitter }} on Twitter
                     </a>
                 {% endif %}
                 {% if page.mastodon %}
-                    <a class="author__link" href="{{ page.mastodon }}" target="_blank">
+                    <a class="author__link" href="{{ page.mastodon }}" target="_blank" rel="noopener noreferrer">
                         {{ page.mastodon }} on Mastodon
                     </a>
                 {% endif %}
                 {% if page.web %}
-                    <a class="author__link" href="{{ page.web }}" target="_blank">
+                    <a class="author__link" href="{{ page.web }}" target="_blank" rel="noopener noreferrer">
                       Site: {{ page.web }}
                     </a>
                 {% endif %}

--- a/source/_layouts/base.twig.html
+++ b/source/_layouts/base.twig.html
@@ -118,8 +118,8 @@
 <footer class="site_footer">
     <div class="center">
         <span class="site_footer__section">&copy; <script type="text/javascript">document.write(new Date().getFullYear());</script> PHP Framework Interop Group.</span>
-        <span class="site_footer__section">Site design by <a class="site_footer__link" href="https://twitter.com/reinink" target="_blank">Jonathan Reinink</a>.</span>
-        <span class="site_footer__section platform_sh_widget">Hosting sponsored by the <a title="platform.sh" href="https://platform.sh/?utm_campaign=sponsored_sites&utm_source=php_fig" target="_blank"><img class="platformsh-logo" src="/img/platform-sh-logo.png" alt="platform.sh logo" style="padding: 0 3px 0 3px;height: 1.1em; vertical-align: text-bottom;"/></a> <a class="site_footer__link" href="https://platform.sh/?utm_campaign=sponsored_sites&utm_source=php_fig" target="_blank">PHP PaaS</a></span>
+        <span class="site_footer__section">Site design by <a class="site_footer__link" href="https://twitter.com/reinink" target="_blank" rel="noopener noreferrer">Jonathan Reinink</a>.</span>
+        <span class="site_footer__section platform_sh_widget">Hosting sponsored by the <a title="platform.sh" href="https://platform.sh/?utm_campaign=sponsored_sites&utm_source=php_fig" target="_blank" rel="noopener noreferrer"><img class="platformsh-logo" src="/img/platform-sh-logo.png" alt="platform.sh logo" style="padding: 0 3px 0 3px;height: 1.1em; vertical-align: text-bottom;"/></a> <a class="site_footer__link" href="https://platform.sh/?utm_campaign=sponsored_sites&utm_source=php_fig" target="_blank" rel="noopener noreferrer">PHP PaaS</a></span>
     </div>
 </footer>
 


### PR DESCRIPTION
﻿## Summary
- Add `rel="noopener noreferrer"` to external links that open in a new tab from author/footer templates
- Fix two small README wording typos in the contribution instructions

## Verification
- `rg --pcre2 -n 'target="_blank"(?![^>]*rel=)' source/_layouts/author.twig.html source/_includes/post-author.twig.html source/_layouts/base.twig.html`
- `git diff --check`

I did not run the full Docker/Sculpin build in this environment.
